### PR TITLE
Add collaboration coefficient

### DIFF
--- a/example.py
+++ b/example.py
@@ -21,6 +21,9 @@ sim.setAgentPrefVelocity(a1, (-1, 1))
 sim.setAgentPrefVelocity(a2, (-1, -1))
 sim.setAgentPrefVelocity(a3, (1, -1))
 
+# Make agent 0 much less collaborative (nominally does 0.5 of the avoidance)
+sim.setAgentCollabCoeff(a0, 0.1)
+
 print('Simulation has %i agents and %i obstacle vertices in it.' %
       (sim.getNumAgents(), sim.getNumObstacleVertices()))
 

--- a/src/Agent.cpp
+++ b/src/Agent.cpp
@@ -346,7 +346,7 @@ namespace RVO {
 				u = (combinedRadius * invTimeStep - wLength) * unitW;
 			}
 
-			line.point = velocity_  + collabCoeff_ * u;// + 0.0f * u;
+			line.point = velocity_  + collabCoeff_ * u;
 			orcaLines_.push_back(line);
 		}
 

--- a/src/Agent.cpp
+++ b/src/Agent.cpp
@@ -36,7 +36,7 @@
 #include "Obstacle.h"
 
 namespace RVO {
-	Agent::Agent(RVOSimulator *sim) : maxNeighbors_(0), maxSpeed_(0.0f), neighborDist_(0.0f), radius_(0.0f), sim_(sim), timeHorizon_(0.0f), timeHorizonObst_(0.0f), id_(0) { }
+	Agent::Agent(RVOSimulator *sim) : maxNeighbors_(0), maxSpeed_(0.0f), neighborDist_(0.0f), radius_(0.0f), sim_(sim), timeHorizon_(0.0f), timeHorizonObst_(0.0f), collabCoeff_(0.5f), id_(0) { }
 
 	void Agent::computeNeighbors()
 	{
@@ -346,7 +346,7 @@ namespace RVO {
 				u = (combinedRadius * invTimeStep - wLength) * unitW;
 			}
 
-			line.point = velocity_ + 0.5f * u;
+			line.point = velocity_  + collabCoeff_ * u;// + 0.0f * u;
 			orcaLines_.push_back(line);
 		}
 

--- a/src/Agent.h
+++ b/src/Agent.h
@@ -100,6 +100,7 @@ namespace RVO {
 		float timeHorizon_;
 		float timeHorizonObst_;
 		Vector2 velocity_;
+		float collabCoeff_;
 
 		size_t id_;
 

--- a/src/RVOSimulator.cpp
+++ b/src/RVOSimulator.cpp
@@ -57,6 +57,7 @@ namespace RVO {
 		defaultAgent_->radius_ = radius;
 		defaultAgent_->timeHorizon_ = timeHorizon;
 		defaultAgent_->timeHorizonObst_ = timeHorizonObst;
+		defaultAgent_->timeHorizonObst_ = timeHorizonObst;
 		defaultAgent_->velocity_ = velocity;
 	}
 
@@ -251,6 +252,11 @@ namespace RVO {
 	{
 		return agents_[agentNo]->timeHorizonObst_;
 	}
+	
+	float RVOSimulator::getAgentCollabCoeff(size_t agentNo) const
+	{
+		return agents_[agentNo]->collabCoeff_;
+	}
 
 	const Vector2 &RVOSimulator::getAgentVelocity(size_t agentNo) const
 	{
@@ -355,6 +361,11 @@ namespace RVO {
 	void RVOSimulator::setAgentTimeHorizonObst(size_t agentNo, float timeHorizonObst)
 	{
 		agents_[agentNo]->timeHorizonObst_ = timeHorizonObst;
+	}
+
+	void RVOSimulator::setAgentCollabCoeff(size_t agentNo, float collabCoeff)
+	{
+		agents_[agentNo]->collabCoeff_ = collabCoeff;
 	}
 
 	void RVOSimulator::setAgentVelocity(size_t agentNo, const Vector2 &velocity)

--- a/src/RVOSimulator.cpp
+++ b/src/RVOSimulator.cpp
@@ -57,7 +57,6 @@ namespace RVO {
 		defaultAgent_->radius_ = radius;
 		defaultAgent_->timeHorizon_ = timeHorizon;
 		defaultAgent_->timeHorizonObst_ = timeHorizonObst;
-		defaultAgent_->timeHorizonObst_ = timeHorizonObst;
 		defaultAgent_->velocity_ = velocity;
 	}
 

--- a/src/RVOSimulator.h
+++ b/src/RVOSimulator.h
@@ -358,6 +358,14 @@ namespace RVO {
 		 *                             retrieved.
 		 * \return     The present two-dimensional linear velocity of the agent.
 		 */
+		float getAgentCollabCoeff(size_t agentNo) const;
+		/**
+		 * \brief      Returns the collaboration coefficient of an agent
+		 * \param      agentNo         The number of the agent whose
+		 *                             collaboration coefficient is to be
+		 *                             retrieved.
+		 * \return     The present collaboration coefficient of the agent.
+		 */
 		const Vector2 &getAgentVelocity(size_t agentNo) const;
 
 		/**
@@ -565,6 +573,16 @@ namespace RVO {
 		 *                             modified.
 		 * \param      velocity        The replacement two-dimensional linear
 		 *                             velocity.
+		 */
+		void setAgentCollabCoeff(size_t agentNo, float collabCoeff);
+
+		/**
+		 * \brief      Sets the collaboration coefficient of a specified
+		 *             agent.
+		 * \param      agentNo         The number of the agent whose
+		 *                             collaboration coefficient is to be
+		 *                             modified.
+		 * \param      collabCoeff        The replacement collaboration coefficient.
 		 */
 		void setAgentVelocity(size_t agentNo, const Vector2 &velocity);
 

--- a/src/rvo2.pyx
+++ b/src/rvo2.pyx
@@ -48,6 +48,7 @@ cdef extern from "RVOSimulator.h" namespace "RVO":
         float getAgentRadius(size_t agentNo) const
         float getAgentTimeHorizon(size_t agentNo) const
         float getAgentTimeHorizonObst(size_t agentNo) const
+        float getAgentCollabCoeff(size_t agentNo) const
         const Vector2 & getAgentVelocity(size_t agentNo) const
         float getGlobalTime() const
         size_t getNumAgents() const
@@ -71,6 +72,7 @@ cdef extern from "RVOSimulator.h" namespace "RVO":
         void setAgentRadius(size_t agentNo, float radius)
         void setAgentTimeHorizon(size_t agentNo, float timeHorizon)
         void setAgentTimeHorizonObst(size_t agentNo, float timeHorizonObst)
+        void setAgentCollabCoeff(size_t agentNo, float collabCoeff)
         void setAgentVelocity(size_t agentNo, const Vector2 & velocity)
         void setTimeStep(float timeStep)
 
@@ -157,6 +159,8 @@ cdef class PyRVOSimulator:
         return self.thisptr.getAgentTimeHorizon(agent_no)
     def getAgentTimeHorizonObst(self, size_t agent_no):
         return self.thisptr.getAgentTimeHorizonObst(agent_no)
+    def getAgentCollabCoeff(self, size_t agent_no):
+        return self.thisptr.getAgentCollabCoeff(agent_no)
     def getAgentVelocity(self, size_t agent_no):
         cdef Vector2 velocity = self.thisptr.getAgentVelocity(agent_no)
         return velocity.x(), velocity.y()
@@ -217,6 +221,8 @@ cdef class PyRVOSimulator:
         self.thisptr.setAgentTimeHorizon(agent_no, time_horizon)
     def setAgentTimeHorizonObst(self, size_t agent_no, float timeHorizonObst):
         self.thisptr.setAgentTimeHorizonObst(agent_no, timeHorizonObst)
+    def setAgentCollabCoeff(self, size_t agent_no, float collab_coeff):
+        self.thisptr.setAgentCollabCoeff(agent_no, collab_coeff)
     def setAgentVelocity(self, size_t agent_no, tuple velocity):
         cdef Vector2 c_velocity = Vector2(velocity[0], velocity[1])
         self.thisptr.setAgentVelocity(agent_no, c_velocity)


### PR DESCRIPTION
Nominal RVO agents add `0.5*u` to their preferred velocity to avoid collisions (essentially doing 1/2 the work). This pull request allows agents to apply a different scalar multiplier, so that some agents will be more collaborative than others.